### PR TITLE
Add FastAPI prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# test
+# Ask-and-Retrieve Prototype
+
+This repo contains a minimal FastAPI backend prototype for the "Ask-and-Retrieve" assistant. It exposes two endpoints:
+
+- `POST /upload` to upload a CSV file with document information.
+- `POST /query` to search the uploaded documents using OpenAI embeddings.
+
+Set `OPENAI_API_KEY` in your environment before running.
+
+Run with:
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,71 @@
+from fastapi import FastAPI, UploadFile, File
+from typing import List
+import csv
+import io
+import os
+
+try:
+    import openai
+except ImportError:
+    openai = None
+
+app = FastAPI(title="Ask-and-Retrieve")
+
+documents = []  # simple in-memory store
+
+def embed_text(text: str) -> List[float]:
+    """Return embedding vector for text. Requires OPENAI_API_KEY env var."""
+    if openai is None:
+        raise RuntimeError("openai package not installed")
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+    openai.api_key = api_key
+    response = openai.Embedding.create(input=[text], model="text-embedding-ada-002")
+    return response["data"][0]["embedding"]
+
+@app.post("/upload")
+async def upload(file: UploadFile = File(...)):
+    """Upload a CSV file with columns: name, physical_location, file_path"""
+    content = await file.read()
+    reader = csv.DictReader(io.StringIO(content.decode()))
+    for row in reader:
+        vector = embed_text(row.get("name", ""))
+        documents.append({
+            "name": row.get("name"),
+            "physical_location": row.get("physical_location"),
+            "file_path": row.get("file_path"),
+            "embedding": vector,
+        })
+    return {"count": len(documents)}
+
+@app.post("/query")
+async def query(text: str):
+    """Query documents using text."""
+    vector = embed_text(text)
+    # compute cosine similarity
+    def cosine(a, b):
+        import math
+        dot = sum(x * y for x, y in zip(a, b))
+        na = math.sqrt(sum(x * x for x in a))
+        nb = math.sqrt(sum(y * y for y in b))
+        return dot / (na * nb)
+
+    if not documents:
+        return {"results": []}
+
+    scored = [
+        (cosine(vector, doc["embedding"]), doc) for doc in documents
+    ]
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    top = [
+        {
+            "name": s[1]["name"],
+            "physical_location": s[1]["physical_location"],
+            "file_path": s[1]["file_path"],
+            "score": s[0],
+        }
+        for s in scored[:5]
+    ]
+    return {"results": top}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+openai


### PR DESCRIPTION
## Summary
- add minimal FastAPI app with `/upload` and `/query`
- document how to run it
- add dependencies and ignore files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685864972b3c8320b66b18db88e8e31a